### PR TITLE
Refactor dwarf_runner.

### DIFF
--- a/dwarfs/dwarf_runner.py
+++ b/dwarfs/dwarf_runner.py
@@ -4,184 +4,147 @@ import subprocess
 import json
 import os
 import time
-import sys
 import signal
-import threading
+import contextlib
 from optparse import OptionParser
 
-# Needed only on OSX
-try:
-    import psutil
-except ImportError:
-    pass
+
+class LinuxEnvironment(object):
+    def __init__(self, sleep_time):
+        self.sleep_time = sleep_time
+
+    @contextlib.contextmanager
+    def provision_browser(self, browser, url):
+        invocation = [browser, '--incognito' if browser == 'google-chrome' else '--private']
+        browser = subprocess.Popen(invocation, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        time.sleep(self.sleep_time)
+        subprocess.call(invocation + [url], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        yield
+        browser.kill()
 
 
-def make_cmdline(browser, system):
-    if OS == "Darwin":
-        if browser == "google-chrome":
-            return ["open", "--background", "-a", "/Applications/Google Chrome.app", "--args", "--incognito"]
-        elif browser == "firefox":
-            return ["open", "--background", "-a", "/Applications/Firefox.app", "--args", "--private"]
-        else:
-            return  ["open", "--background", "-a", "/Applications/Safari.app"]
-    elif OS == "Linux":
-        return [browser, "--incognito" if browser == "google-chrome" else "--private"]
+class OsxEnvironment(object):
+    def __init__(self, sleep_time):
+        import psutil
+        self.sleep_time = sleep_time
 
-
-class WebbenchThread(threading.Thread):
-    def __init__(self):
-        threading.Thread.__init__(self)
-        self.out = "[]"
-
-    def run(self):
-        webserver_script = ["python", "webbench.py"]
-        stdout, stderr = subprocess.Popen(webserver_script,
-                                          stdout=subprocess.PIPE,
-                                          stderr=subprocess.PIPE).communicate()
-        self.out = stdout[:]
+    @contextlib.contextmanager
+    def provision_browser(self, browser, url):
+        browser_args = {
+            'google-chrome': ['/Applications/Google Chrome.app', '--args', '--incognito'],
+            'firefox': ['/Applications/Firefox.app', '--args', '--private'],
+            'safari': ['/Applications/Safari.app']
+        }
+        invocation = ['open', '--background', '-a'] + browser_args[browser]
+        browser = subprocess.Popen(invocation, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        time.sleep(self.sleep_time)
+        subprocess.call([invocation[0], url] + invocation[1:], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        yield
+        browsers = {'google-chrome': 'Google Chrome', 'firefox': 'firefox', 'safari': 'Safari'}
+        pids = [p.pid for p in psutil.get_process_list() if p.name == browsers[browser]]
+        os.kill(pids[0], signal.SIGKILL)
 
 
 class Benchmark(object):
-    def __init__(self, name, dir):
+    def __init__(self, name, dir, env, iters):
         self.name = name
         self.dir = dir
+        self.env = env
+        self.iters = iters
+
+    @contextlib.contextmanager
+    def cd(self):
+        cwd = os.getcwd()
+        os.chdir(self.dir)
+        yield
+        os.chdir(cwd)
 
     def run_c_benchmark(self):
         """Run the C benchmark.  Assume that there is a build/c/run.sh script
            that will feed all the correct parameters."""
-
-        prev_dir = os.getcwd()
-        os.chdir(self.dir)
-
         runner_script = ["sh", os.path.join("build", "c", "run.sh")]
-        results = []
-        for _ in xrange(ITERS):
-            stdout, stderr = subprocess.Popen(runner_script,
-                                              stdout=subprocess.PIPE,
-                                              stderr=subprocess.PIPE).communicate()
-            result = json.loads(stdout)
-            results.append(result)
-        os.chdir(prev_dir)
-        return [r['time'] for r in results]
-
+        with self.cd():
+            for _ in xrange(self.iters):
+                stdout, _ = subprocess.Popen(runner_script,
+                                             stdout=subprocess.PIPE,
+                                             stderr=subprocess.PIPE).communicate()
+                yield json.loads(stdout)['time']
 
     def run_js_benchmark(self, browser, asmjs=False):
         httpd = subprocess.Popen(["python", "webbench.py"], stdout=subprocess.PIPE)
         url = "http://0.0.0.0:8080/static/" + os.path.join(self.dir, "build", "asmjs" if asmjs else "js", "run.html")
-        browser_script = make_cmdline(browser, OS)
-        results = []
 
-        for _ in xrange(ITERS):
-            br = subprocess.Popen(browser_script, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            time.sleep(SLEEP_TIME)
-            if OS == "Darwin":
-                browser_script2 = [browser_script[0]] + [url] + browser_script[1:]
-                subprocess.call(browser_script2, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            else:
-                subprocess.call(browser_script + [url], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            line = httpd.stdout.readline()
-            obj = json.loads(line)
-            results.append(obj)
-            if OS == "Darwin":
-                browsers = { "google-chrome": "Google Chrome", "firefox": "firefox", "safari": "Safari" }
-                pids = [p.pid for p in psutil.get_process_list() if p.name == browsers[browser]]
-                os.kill(pids[0], signal.SIGKILL)
-            else:
-                br.kill()
+        for _ in xrange(self.iters):
+            with self.env.provision_browser(browser, url):
+                yield json.loads(httpd.stdout.readline())['time']
 
         httpd.kill()
-        return [r['time'] for r in results]
-
 
     def build(self):
         """Move into the benchmark's directory and run make clean && make."""
+        with self.cd():
+            subprocess.call(["make", "clean"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            subprocess.call(["make"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
-        prev_dir = os.getcwd()
-        os.chdir(self.dir)
-        subprocess.call(["make", "clean"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        subprocess.call(["make"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        os.chdir(prev_dir)
 
-OS = os.uname()[0]
-ITERS = 10
-BENCHMARKS = [
-    Benchmark("nqueens", "branch-and-bound/nqueens"),
-    Benchmark("crc", "combinational-logic/crc"),
-    Benchmark("lud", "dense-linear-algebra/lud"),
-    Benchmark("nw", "dynamic-programming/nw"),
-    Benchmark("hmm", "graphical-models/hmm"),
-    Benchmark("bfs", "graph-traversal/bfs"),
-    Benchmark("page-rank", "map-reduce/page-rank"),
-    Benchmark("lavamd", "n-body-methods/lavamd"),
-    #Benchmark("spmv", "sparse-linear-algebra/spmv"),
-    Benchmark("fft", "spectral-methods/fft"),
-    Benchmark("srad", "structured-grid/SRAD"),
-    Benchmark("back-prop", "unstructured-grid/back-propagation"),
-]
+BENCHMARK_INFO = dict([
+    ("nqueens", "branch-and-bound/nqueens"),
+    ("crc", "combinational-logic/crc"),
+    ("lud", "dense-linear-algebra/lud"),
+    ("nw", "dynamic-programming/nw"),
+    ("hmm", "graphical-models/hmm"),
+    ("bfs", "graph-traversal/bfs"),
+    ("page-rank", "map-reduce/page-rank"),
+    ("lavamd", "n-body-methods/lavamd"),
+    ("spmv", "sparse-linear-algebra/spmv"),
+    ("fft", "spectral-methods/fft"),
+    ("srad", "structured-grid/SRAD"),
+    ("back-prop", "unstructured-grid/back-propagation"),
+])
 
-benchmark_names = [b.name for b in BENCHMARKS]
-environments = ["c",
-                "asmjs-chrome",
-                "asmjs-firefox",
-                "js-chrome",
-                "js-firefox",
-                "asmjs-safari",
-                "js-safari"]
+ENVIRONMENTS = {
+    'c': ('C', 'N/A', lambda b: b.run_c_benchmark()),
+    'asmjs-chrome': ('asmjs', 'Chrome', lambda b: b.run_js_benchmark('google-chrome', True)),
+    'asmjs-firefox': ('asmjs', 'Firefox', lambda b: b.run_js_benchmark('firefox', True)),
+    "js-chrome": ('js', 'Chrome', lambda b: b.run_js_benchmark('google-chrome')),
+    "js-firefox": ('js', 'Firefox', lambda b: b.run_js_benchmark('firefox')),
+    'asmjs-safari': ('asmjs', 'Safari', lambda b: b.run_js_benchmark('safari', True)),
+    'js-safari': ('js', 'Safari', lambda b: b.run_js_benchmark('safari')),
+}
 
-parser = OptionParser()
-parser.add_option("-b", "--benchmarks", dest="benchmark_csv",
-                  metavar="bench1,bench2,...",
-                  help="comma-separated list of benchmarks to run (" +
-                  ", ".join(benchmark_names) + ")")
-parser.add_option("-e", "--environments", dest="env_csv",
-                  metavar="env1,env2,...",
-                  help="comma-separated list of environments to use " +
-                  "(" + ", ".join(environments) + ")")
-parser.add_option("-i", "--iterations", dest="iters",
-                  action="store", type="int",
-                  help="number of iteration for each benchmark")
-parser.add_option("-w", "--wait-before-load", dest="wait",
-                  action="store", type="int",
-                  help="number of seconds to wait after having started the browser before sending the load command")
-(options, args) = parser.parse_args()
 
-if options.benchmark_csv is None:
-    benchmarks_to_run = benchmark_names
-else:
-    benchmarks_to_run = [b.strip() for b in options.benchmark_csv.split(",")]
+def parse_options():
+    parser = OptionParser()
+    parser.add_option("-b", "--benchmarks", dest="benchmark_csv",
+                      metavar="bench1,bench2,...", default=','.join(BENCHMARK_INFO),
+                      help="comma-separated list of benchmarks to run (%default)")
+    parser.add_option("-e", "--environments", dest="env_csv",
+                      metavar="env1,env2,...", default=','.join(ENVIRONMENTS),
+                      help="comma-separated list of environments to use (%default)")
+    parser.add_option("-i", "--iterations", dest="iters",
+                      action="store", type="int", default=10,
+                      help="number of iteration for each benchmark")
+    parser.add_option("-w", "--wait-before-load", dest="wait",
+                      action="store", type="int", default=6,
+                      help="number of seconds to wait after having started the browser before sending the load command")
+    return parser.parse_args()[0]
 
-if options.env_csv is None:
-    environments_to_use = environments
-else:
-    environments_to_use = [b.strip() for b in options.env_csv.split(",")]
 
-ITERS = options.iters or 10
-SLEEP_TIME = options.wait or 6
+def main():
+    options = parse_options()
+    OS = (OsxEnvironment if os.uname()[0] == 'Darwin' else LinuxEnvironment)(options.wait)
 
-print "benchmark,language,browser,%s" % ",".join("time" + str(i) for i in xrange(ITERS))
+    benchmarks_to_run = [
+        Benchmark(name, BENCHMARK_INFO[name], OS, options.iters)
+        for name in options.benchmark_csv.strip().split(',')
+    ]
+    environments_to_use = map(ENVIRONMENTS.get, options.env_csv.strip().split(","))
 
-for b in BENCHMARKS:
-    if b.name not in benchmarks_to_run:
-        continue
-    b.build()
+    print "benchmark,language,browser,%s" % ",".join("time" + str(i) for i in xrange(options.iters))
+    for b in benchmarks_to_run:
+        b.build()
+        for env in environments_to_use:
+            print ','.join([b.name, env[0], env[1], ','.join(map(str, env[2](b)))])
 
-    if "c" in environments_to_use:
-        print "%s,C,N/A,%s" % (b.name, ','.join(str(x) for x in b.run_c_benchmark()))
-
-    if "asmjs-chrome" in environments_to_use:
-        print "%s,asmjs,Chrome,%s" % (b.name, ','.join(str(x) for x in b.run_js_benchmark("google-chrome", True)))
-
-    if "asmjs-firefox" in environments_to_use:
-        print "%s,asmjs,Firefox,%s" % (b.name, ','.join(str(x) for x in b.run_js_benchmark("firefox", True)))
-
-    if "asmjs-safari" in environments_to_use and OS == "Darwin":
-        print "%s,asmjs,Safari,%s" % (b.name, ','.join(str(x) for x in b.run_js_benchmark("safari", True)))
-
-    if "js-chrome" in environments_to_use:
-        print "%s,js,Chrome,%s" % (b.name, ','.join(str(x) for x in b.run_js_benchmark("google-chrome")))
-
-    if "js-firefox" in environments_to_use:
-        print "%s,js,Firefox,%s" % (b.name, ','.join(str(x) for x in b.run_js_benchmark("firefox")))
-
-    if "js-safari" in environments_to_use and OS == "Darwin":
-        print "%s,js,Safari,%s" % (b.name, ','.join(str(x) for x in b.run_js_benchmark("safari")))
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Summary of changes:
- Removed WebbenchThread (apparently not used).
- Factored out OS-specific bits into `OsxEnvironment` and `LinuxEnvironment`
  classes, each providing a `provision_browser(browser, url)` context manager,
  which are passed into `Benchmark`.
- Added a neato `cd()` context manager on `Benchmark`, allowing you to write
  `with self.cd():`
- Turned `run_c_benchmark` and `run_js_benchmark` into generators
- Simplified options parsing a bit; `optparse` allows you to set defaults, and
  a `%default` placeholder in the help text expands to the default value.
  (Also removed global variables, instead passing options where they need to go).
- Reduced duplication in the environments; specify each environment as a tuple
  of language, browser, and function taking a benchmark and returning a generator
  of the results.

n.b. I use dicts for specifying benchmarks and environments where previously
lists were used, so order is not necessarily preserved. If this matters to you,
you should use `collections.OrderedDict`s instead.

n.b. I only did cursory testing of this, since e.g. I don't have emscripten
installed, and I am on OS X.
